### PR TITLE
docs: Add README for OctoAcme Project Management Docs

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,90 @@
+# OctoAcme Project Management Docs
+
+This README provides a summary of OctoAcme's project management practices and quick links to all process documentation.
+
+## Summary of Project Management Processes
+
+OctoAcme projects use an **iterative, evidence-driven approach** with defined roles, structured planning, risk management, clear execution rhythms, and regular reviews.
+
+### Core Principles
+
+Our project management framework is built on five key principles:
+
+- **Customer-first**: Prioritize customer value and usability in every decision.
+- **Iterative delivery**: Deliver small, testable increments rather than large, monolithic releases.
+- **Clear ownership**: Each project has a named Project Manager (PM) and Product Lead with defined responsibilities.
+- **Data-informed decisions**: Measure impact and iterate based on evidence and metrics.
+- **Psychological safety**: Encourage feedback, learning, and continuous improvement.
+
+### Project Lifecycle
+
+All OctoAcme projects follow a structured five-phase lifecycle:
+
+1. **Initiation** — Validate business need, align stakeholders, define success metrics, and confirm resource availability.
+2. **Planning** — Break work into shippable increments, identify dependencies, align timelines, and establish a Definition of Done.
+3. **Execution** — Build, test, review, and iterate with daily standups, weekly syncs, and regular demos.
+4. **Release** — Deploy to production with careful planning, smoke testing, rollback plans, and stakeholder communication.
+5. **Retrospective & Continuous Improvement** — Capture learnings and translate them into actionable improvements.
+
+### Key Roles
+
+- **Project Manager (PM)** — Coordinates delivery, manages schedules, risks, and communications.
+- **Product Manager (PdM)** — Defines outcomes, prioritizes the backlog, and measures success.
+- **Developers** — Implement features, collaborate on design, and maintain code quality.
+- **QA/Testing** — Validate quality and ensure acceptance criteria are met.
+- **Stakeholders** — Provide inputs, approvals, and strategic direction.
+
+### Core Artifacts
+
+Each project maintains these key living documents:
+
+- **Project Charter / One-pager** — Problem statement, goals, success metrics, and stakeholders.
+- **Roadmap and Release Plan** — Timeline of features and releases.
+- **Sprint/Iteration Backlog** — Prioritized work items with acceptance criteria and estimates.
+- **Risk Register** — Identified risks with impact, likelihood, mitigation plans, and owners.
+- **Retrospective Notes** — Learnings and action items for continuous improvement.
+
+## Quick Links to Process Docs
+
+- **[Project Management Overview](octoacme-project-management-overview.md)** — Core principles, lifecycle, roles, and artifacts.
+- **[Project Initiation Guide](octoacme-project-initiation.md)** — Steps to validate, align, and launch new projects.
+- **[Project Planning](octoacme-project-planning.md)** — Backlog creation, estimation, dependency identification, and definition of done.
+- **[Execution & Tracking](octoacme-execution-and-tracking.md)** — Standups, project boards, PR/contribution flow, reporting, blockers, and QA.
+- **[Risk Management & Communication](octoacme-risks-and-communication.md)** — Documenting and escalating risks, stakeholder comms, templates for status and incidents.
+- **[Release & Deployment Guide](octoacme-release-and-deployment.md)** — Releasing to production, checklists, release notes, and rollback playbooks.
+- **[Retrospective & Continuous Improvement](octoacme-retrospective-and-continuous-improvement.md)** — Capturing learnings and translating them into action items.
+- **[Roles & Personas](octoacme-roles-and-personas.md)** — Team roles and responsibilities reference for project activities.
+
+## Communication Cadence
+
+- **Daily standups** (15 min) — Focus on progress, blockers, and dependencies.
+- **Weekly PM + PdM sync** — Strategic alignment and risk review.
+- **Twice-weekly team standups** — Delivery updates and coordination (or as agreed).
+- **Monthly stakeholder updates** — High-level progress, milestones, and decisions.
+- **Ad-hoc escalations** — Risk, blocker, or incident-driven communications.
+
+## Getting Started
+
+**For new team members or projects:**
+1. Start with the [Project Management Overview](octoacme-project-management-overview.md) for a quick introduction.
+2. Follow the [Project Initiation Guide](octoacme-project-initiation.md) to set up a new project.
+3. Use [Project Planning](octoacme-project-planning.md) to structure your backlog and timeline.
+4. Reference [Execution & Tracking](octoacme-execution-and-tracking.md) during delivery.
+5. Consult [Risk Management & Communication](octoacme-risks-and-communication.md) whenever risks arise.
+6. Use [Release & Deployment Guide](octoacme-release-and-deployment.md) before going live.
+7. Conduct [Retrospectives](octoacme-retrospective-and-continuous-improvement.md) at project milestones.
+
+**For role-specific guidance:**
+- See [Roles & Personas](octoacme-roles-and-personas.md) for responsibilities and typical communication patterns.
+
+## Key Takeaways
+
+✅ **Clear structure** — Every phase has defined objectives, activities, and deliverables.  
+✅ **Risk-aware** — We identify, monitor, and escalate risks early.  
+✅ **Quality-focused** — Testing, reviews, and acceptance criteria are non-negotiable.  
+✅ **Transparent** — Regular syncs, status updates, and escalation paths keep everyone informed.  
+✅ **Learning-oriented** — Retrospectives and action items drive continuous improvement.
+
+---
+
+**Questions?** Reach out to your Project Manager or Product Lead, or refer to the specific process doc that addresses your need.


### PR DESCRIPTION
## Summary
Adds a comprehensive README file to the `docs/` folder that serves as a central entry point for all OctoAcme project management process documentation.

## Changes
- Creates `docs/README.md` with:
  - Overview of project management principles and lifecycle
  - Summary of core roles and artifacts
  - Quick links to all 8 process documentation files
  - Communication cadence and getting-started guidance
  - Role-specific guidance for different team members

Closes #2